### PR TITLE
Rotor rebalance 2

### DIFF
--- a/kubejs/assets/emi/index/stacks/rotor_rebalance.json
+++ b/kubejs/assets/emi/index/stacks/rotor_rebalance.json
@@ -1,0 +1,16 @@
+{
+  "removed": [
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:magnalium\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:wrought_iron\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:manganese\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:molybdenum\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:iron\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:neodymium\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:brass\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:cobalt_brass\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:rose_gold\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:sterling_silver\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:tungsten\"}}"
+  ],
+  "disable": true
+}

--- a/kubejs/assets/emi/index/stacks/rotor_rebalance.json
+++ b/kubejs/assets/emi/index/stacks/rotor_rebalance.json
@@ -11,7 +11,8 @@
     "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:rose_gold\"}}",
     "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:sterling_silver\"}}",
     "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:tungsten\"}}",
-    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:iridium\"}}"
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:iridium\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:chromium\"}}"
   ],
   "disable": true
 }

--- a/kubejs/assets/emi/index/stacks/rotor_rebalance.json
+++ b/kubejs/assets/emi/index/stacks/rotor_rebalance.json
@@ -10,7 +10,8 @@
     "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:cobalt_brass\"}}",
     "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:rose_gold\"}}",
     "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:sterling_silver\"}}",
-    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:tungsten\"}}"
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:tungsten\"}}",
+    "item:gtceu:turbine_rotor{GT.PartStats:{Material:\"gtceu:iridium\"}}"
   ],
   "disable": true
 }

--- a/kubejs/server_scripts/gregtech/netherite.js
+++ b/kubejs/server_scripts/gregtech/netherite.js
@@ -132,6 +132,7 @@ ServerEvents.recipes(event => {
         `${namespace}:${material}_huge_fluid_pipe`,
         `${namespace}:${material}_quadruple_fluid_pipe`,
         `${namespace}:${material}_nonuple_fluid_pipe`,
+        `${namespace}:${material}_turbine_blade`
     ]}
 
     let crystal_matrix_forms = tagPrefixes("crystal_matrix", "monilabs")
@@ -144,4 +145,12 @@ ServerEvents.recipes(event => {
             "kubejs:inert_nether_compound_ingot"
         )
     })
+
+    // Turbine blades shouldn't be Smithed
+    event.recipes.gtceu.assembler("assemble_activated_netherite_turbine_blade")
+        .itemInputs("8x gtceu:activated_netherite_turbine_blade", "gtceu:long_magnalium_rod")
+        .itemOutputs(Item.of("gtceu:turbine_rotor", "{GT.PartStats:{Material:\"gtceu:activated_netherite\"}}"))
+        .duration(10 * GTValues.SECONDS)
+        .EUt(400)
+
 })

--- a/kubejs/server_scripts/gregtech/netherite.js
+++ b/kubejs/server_scripts/gregtech/netherite.js
@@ -146,7 +146,7 @@ ServerEvents.recipes(event => {
         )
     })
 
-    // Turbine blades shouldn't be Smithed
+    // Turbine rotors shouldn't be smithed, only the individual blades
     event.recipes.gtceu.assembler("assemble_activated_netherite_turbine_blade")
         .itemInputs("8x gtceu:activated_netherite_turbine_blade", "gtceu:long_magnalium_rod")
         .itemOutputs(Item.of("gtceu:turbine_rotor", "{GT.PartStats:{Material:\"gtceu:activated_netherite\"}}"))

--- a/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
@@ -31,7 +31,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0x035155).secondaryColor(0x04203d).iconSet("dull")
         .blastTemp(6800, "higher")
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_ROTOR)
-        .rotorStats(180, 150, 5.0, 5120)
+        .rotorStats(200, 150, 5.0, 5120)
 
     event.create("cryococcus")
         .ingot().fluid()

--- a/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
@@ -30,7 +30,8 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .element(GTElements.get("cryolobus"))
         .color(0x035155).secondaryColor(0x04203d).iconSet("dull")
         .blastTemp(6800, "higher")
-        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FRAME)
+        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_ROTOR)
+        .rotorStats(180, 150, 5.0, 5120)
 
     event.create("cryococcus")
         .ingot().fluid()
@@ -78,13 +79,15 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .fluidPipeProperties(12500, 800, true, false, false, true)
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_ROTOR, GTMaterialFlags.NO_UNIFICATION)
         .ignoredTagPrefixes([TagPrefix.dust, TagPrefix.dustSmall, TagPrefix.dustTiny, TagPrefix.nugget, TagPrefix.ring, TagPrefix.bolt, TagPrefix.screw])
+        .rotorStats(300, 400, 10.0, 655360)
 
     event.create("ardite")
         .ingot().fluid()
         .color(0xad2f05).secondaryColor(0x823c08)
         .iconSet("dull")
         .blastTemp(9200, "highest", GTValues.VHA[GTValues.UV], 1000)
-        .flags(GTMaterialFlags.GENERATE_PLATE)
+        .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROTOR)
+        .rotorStats(280, 280, 10.0, 655360)
 
     event.create("manyullyn")
         .ingot().fluid()

--- a/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
@@ -31,7 +31,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0x035155).secondaryColor(0x04203d).iconSet("dull")
         .blastTemp(6800, "higher")
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_ROTOR)
-        .rotorStats(200, 150, 5.0, 5120)
+        .rotorStats(200, 200, 5.0, 5120)
 
     event.create("cryococcus")
         .ingot().fluid()

--- a/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
+++ b/kubejs/startup_scripts/gregtech_material_registry/moni_originals.js
@@ -31,7 +31,7 @@ GTCEuStartupEvents.registry("gtceu:material", event => {
         .color(0x035155).secondaryColor(0x04203d).iconSet("dull")
         .blastTemp(6800, "higher")
         .flags(GTMaterialFlags.GENERATE_PLATE, GTMaterialFlags.GENERATE_ROD, GTMaterialFlags.GENERATE_DENSE, GTMaterialFlags.GENERATE_FRAME, GTMaterialFlags.GENERATE_ROTOR)
-        .rotorStats(200, 200, 5.0, 5120)
+        .rotorStats(280, 180, 5.0, 5120)
 
     event.create("cryococcus")
         .ingot().fluid()

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -154,6 +154,7 @@ global.itemNukeList = [
     "gtceu:sterling_silver_turbine_blade",
     "gtceu:tungsten_turbine_blade",
     "gtceu:iridium_turbine_blade",
+    "gtceu:chromium_turbine_blade",
 
     // Hammerlib
     /^hammerlib:/,

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -141,6 +141,19 @@ global.itemNukeList = [
     /^gtmutils:uxv/,
     /^gtmutils:opv/,
 
+    // Turbine rotor rebalance
+    "gtceu:magnalium_turbine_blade",
+    "gtceu:wrought_iron_turbine_blade",
+    "gtceu:manganese_turbine_blade",
+    "gtceu:molybdenum_turbine_blade",
+    "gtceu:iron_turbine_blade",
+    "gtceu:neodymium_turbine_blade",
+    "gtceu:brass_turbine_blade",
+    "gtceu:cobalt_brass_turbine_blade",
+    "gtceu:rose_gold_turbine_blade",
+    "gtceu:sterling_silver_turbine_blade",
+    "gtceu:tungsten_turbine_blade",
+
     // Hammerlib
     /^hammerlib:/,
 

--- a/kubejs/startup_scripts/nukeLists/item.js
+++ b/kubejs/startup_scripts/nukeLists/item.js
@@ -153,6 +153,7 @@ global.itemNukeList = [
     "gtceu:rose_gold_turbine_blade",
     "gtceu:sterling_silver_turbine_blade",
     "gtceu:tungsten_turbine_blade",
+    "gtceu:iridium_turbine_blade",
 
     // Hammerlib
     /^hammerlib:/,

--- a/kubejs/startup_scripts/rotor_rebalance.js
+++ b/kubejs/startup_scripts/rotor_rebalance.js
@@ -7,22 +7,23 @@ const $MoniMaterials = Java.loadClass("net.neganote.monilabs.common.data.materia
 GTCEuStartupEvents.materialModification(event => {
     // Existing rotors
     GTMaterials.Ultimet.getProperty(PropertyKey.ROTOR).setEfficiency(90)           // nerf
-    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setEfficiency(200)
-    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setPower(170)  // buff
-    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR).setPower(190)               // buff
-    GTMaterials.RhodiumPlatedPalladium.getProperty(PropertyKey.ROTOR).setEfficiency(200)    // buff
-    GTMaterials.HSSG.getProperty(PropertyKey.ROTOR).setPower(170)                   // nerf
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setEfficiency(220)
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setPower(180)  // buff
+    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR).setPower(200)               // buff
+    GTMaterials.RhodiumPlatedPalladium.getProperty(PropertyKey.ROTOR).setEfficiency(220)    // buff
+    GTMaterials.HSSG.getProperty(PropertyKey.ROTOR).setPower(180)                   // nerf
     GTMaterials.StainlessSteel.getProperty(PropertyKey.ROTOR).setPower(150)         // nerf
     GTMaterials.HSSS.getProperty(PropertyKey.ROTOR).setPower(180)                   // nerf
     GTMaterials.HSSE.getProperty(PropertyKey.ROTOR).setPower(190)                   // nerf
-    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR).setPower(220)          // buff
+    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR).setPower(240)          // buff
     GTMaterials.TungstenCarbide.getProperty(PropertyKey.ROTOR).setPower(155)        // nerf
     GTMaterials.TungstenSteel.getProperty(PropertyKey.ROTOR).setPower(175)          // buff
+    GTMaterials.Tritanium.getProperty(PropertyKey.ROTOR).setPower(260)              // buff
 
     // New turbine rotors from existing GT Materials
-    let DarmstadtiumTurbineProperty = new $RotorProperty(240, 150, 7.0, 10240)
+    let DarmstadtiumTurbineProperty = new $RotorProperty(280, 150, 7.0, 10240)
     GTMaterials.Darmstadtium.setProperty(PropertyKey.ROTOR, DarmstadtiumTurbineProperty)
 
-    let CrystalMatrixTurbineProperty = new $RotorProperty(200, 270, 6.0, 10240)
+    let CrystalMatrixTurbineProperty = new $RotorProperty(220, 270, 6.0, 10240)
     $MoniMaterials.CrystalMatrix.setProperty(PropertyKey.ROTOR, CrystalMatrixTurbineProperty)
 })

--- a/kubejs/startup_scripts/rotor_rebalance.js
+++ b/kubejs/startup_scripts/rotor_rebalance.js
@@ -1,0 +1,40 @@
+/*
+ * Rebalance turbine power and fuel efficiency across the board to pair with durability being mixin'd out of existence.
+ */
+const $RotorProperty = Java.loadClass("com.gregtechceu.gtceu.api.data.chemical.material.properties.RotorProperty")
+const $MoniMaterials = Java.loadClass("net.neganote.monilabs.common.data.materials.MoniMaterials")
+
+GTCEuStartupEvents.materialModification(event => {
+    // Existing rotors
+    GTMaterials.Ultimet.getProperty(PropertyKey.ROTOR)// .setDurability(6500)              // Now 240000, Previously 113600
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Bronze.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Invar.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Steel.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Tritanium.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Osmium.getProperty(PropertyKey.ROTOR)
+    GTMaterials.BlackBronze.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Chromium.getProperty(PropertyKey.ROTOR)
+    GTMaterials.VanadiumSteel.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR)
+    GTMaterials.RhodiumPlatedPalladium.getProperty(PropertyKey.ROTOR)
+    GTMaterials.HSSG.getProperty(PropertyKey.ROTOR)
+    GTMaterials.StainlessSteel.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Neutronium.getProperty(PropertyKey.ROTOR)
+    GTMaterials.HSSS.getProperty(PropertyKey.ROTOR)
+    GTMaterials.HSSE.getProperty(PropertyKey.ROTOR)
+    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Iridium.getProperty(PropertyKey.ROTOR)
+    GTMaterials.TungstenSteel.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Aluminium.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Titanium.getProperty(PropertyKey.ROTOR)
+    GTMaterials.BismuthBronze.getProperty(PropertyKey.ROTOR)
+    GTMaterials.TungstenCarbide.getProperty(PropertyKey.ROTOR)
+
+    // New turbine rotors from existing GT Materials
+    let DarmstadtiumTurbineProperty = new $RotorProperty(240, 120, 7.0, 10240)
+    GTMaterials.Darmstadtium.setProperty(PropertyKey.ROTOR, DarmstadtiumTurbineProperty)
+
+    let CrystalMatrixTurbineProperty = new $RotorProperty(200, 270, 6.0, 10240)
+    $MoniMaterials.CrystalMatrix.setProperty(PropertyKey.ROTOR, CrystalMatrixTurbineProperty)
+})

--- a/kubejs/startup_scripts/rotor_rebalance.js
+++ b/kubejs/startup_scripts/rotor_rebalance.js
@@ -6,22 +6,19 @@ const $MoniMaterials = Java.loadClass("net.neganote.monilabs.common.data.materia
 
 GTCEuStartupEvents.materialModification(event => {
     // Existing rotors
-    GTMaterials.Ultimet.getProperty(PropertyKey.ROTOR).setEfficiency(90)           // nerf
-    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setEfficiency(220)
-    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setPower(180)  // buff
-    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR).setPower(200)               // buff
-    GTMaterials.RhodiumPlatedPalladium.getProperty(PropertyKey.ROTOR).setEfficiency(220)    // buff
-    GTMaterials.HSSG.getProperty(PropertyKey.ROTOR).setPower(180)                   // nerf
-    GTMaterials.StainlessSteel.getProperty(PropertyKey.ROTOR).setPower(150)         // nerf
-    GTMaterials.HSSS.getProperty(PropertyKey.ROTOR).setPower(180)                   // nerf
-    GTMaterials.HSSE.getProperty(PropertyKey.ROTOR).setPower(190)                   // nerf
-    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR).setPower(240)          // buff
-    GTMaterials.TungstenCarbide.getProperty(PropertyKey.ROTOR).setPower(155)        // nerf
-    GTMaterials.TungstenSteel.getProperty(PropertyKey.ROTOR).setPower(175)          // buff
-    GTMaterials.Tritanium.getProperty(PropertyKey.ROTOR).setPower(260)              // buff
+    GTMaterials.Ultimet.getProperty(PropertyKey.ROTOR).setPower(150)                // nerf from 160
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setEfficiency(220)        // buff from 130
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setPower(180)             // buff from 130
+    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR).setPower(200)               // buff from 160
+    GTMaterials.RhodiumPlatedPalladium.getProperty(PropertyKey.ROTOR).setEfficiency(220)    // buff from 155
+    GTMaterials.HSSG.getProperty(PropertyKey.ROTOR).setPower(170)                   // nerf from 205
+    GTMaterials.HSSS.getProperty(PropertyKey.ROTOR).setPower(180)                   // nerf from 250
+    GTMaterials.HSSE.getProperty(PropertyKey.ROTOR).setPower(190)                   // nerf from 280
+    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR).setPower(240)          // buff from 190
+    GTMaterials.TungstenSteel.getProperty(PropertyKey.ROTOR).setPower(180)          // buff from 160
 
     // New turbine rotors from existing GT Materials
-    let DarmstadtiumTurbineProperty = new $RotorProperty(280, 150, 7.0, 10240)
+    let DarmstadtiumTurbineProperty = new $RotorProperty(270, 150, 7.0, 10240)
     GTMaterials.Darmstadtium.setProperty(PropertyKey.ROTOR, DarmstadtiumTurbineProperty)
 
     let CrystalMatrixTurbineProperty = new $RotorProperty(220, 270, 6.0, 10240)

--- a/kubejs/startup_scripts/rotor_rebalance.js
+++ b/kubejs/startup_scripts/rotor_rebalance.js
@@ -6,33 +6,21 @@ const $MoniMaterials = Java.loadClass("net.neganote.monilabs.common.data.materia
 
 GTCEuStartupEvents.materialModification(event => {
     // Existing rotors
-    GTMaterials.Ultimet.getProperty(PropertyKey.ROTOR)// .setDurability(6500)              // Now 240000, Previously 113600
-    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Bronze.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Invar.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Steel.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Tritanium.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Osmium.getProperty(PropertyKey.ROTOR)
-    GTMaterials.BlackBronze.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Chromium.getProperty(PropertyKey.ROTOR)
-    GTMaterials.VanadiumSteel.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR)
-    GTMaterials.RhodiumPlatedPalladium.getProperty(PropertyKey.ROTOR)
-    GTMaterials.HSSG.getProperty(PropertyKey.ROTOR)
-    GTMaterials.StainlessSteel.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Neutronium.getProperty(PropertyKey.ROTOR)
-    GTMaterials.HSSS.getProperty(PropertyKey.ROTOR)
-    GTMaterials.HSSE.getProperty(PropertyKey.ROTOR)
-    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Iridium.getProperty(PropertyKey.ROTOR)
-    GTMaterials.TungstenSteel.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Aluminium.getProperty(PropertyKey.ROTOR)
-    GTMaterials.Titanium.getProperty(PropertyKey.ROTOR)
-    GTMaterials.BismuthBronze.getProperty(PropertyKey.ROTOR)
-    GTMaterials.TungstenCarbide.getProperty(PropertyKey.ROTOR)
+    GTMaterials.Ultimet.getProperty(PropertyKey.ROTOR).setEfficiency(90)           // nerf
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setEfficiency(200)
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setPower(170)  // buff
+    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR).setPower(190)               // buff
+    GTMaterials.RhodiumPlatedPalladium.getProperty(PropertyKey.ROTOR).setEfficiency(200)    // buff
+    GTMaterials.HSSG.getProperty(PropertyKey.ROTOR).setPower(170)                   // nerf
+    GTMaterials.StainlessSteel.getProperty(PropertyKey.ROTOR).setPower(150)         // nerf
+    GTMaterials.HSSS.getProperty(PropertyKey.ROTOR).setPower(180)                   // nerf
+    GTMaterials.HSSE.getProperty(PropertyKey.ROTOR).setPower(190)                   // nerf
+    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR).setPower(220)          // buff
+    GTMaterials.TungstenCarbide.getProperty(PropertyKey.ROTOR).setPower(155)        // nerf
+    GTMaterials.TungstenSteel.getProperty(PropertyKey.ROTOR).setPower(175)          // buff
 
     // New turbine rotors from existing GT Materials
-    let DarmstadtiumTurbineProperty = new $RotorProperty(240, 120, 7.0, 10240)
+    let DarmstadtiumTurbineProperty = new $RotorProperty(240, 150, 7.0, 10240)
     GTMaterials.Darmstadtium.setProperty(PropertyKey.ROTOR, DarmstadtiumTurbineProperty)
 
     let CrystalMatrixTurbineProperty = new $RotorProperty(200, 270, 6.0, 10240)

--- a/kubejs/startup_scripts/rotor_rebalance.js
+++ b/kubejs/startup_scripts/rotor_rebalance.js
@@ -7,18 +7,16 @@ const $MoniMaterials = Java.loadClass("net.neganote.monilabs.common.data.materia
 GTCEuStartupEvents.materialModification(event => {
     // Existing rotors
     GTMaterials.Ultimet.getProperty(PropertyKey.ROTOR).setPower(150)                // nerf from 160
-    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setEfficiency(220)        // buff from 130
+    GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setEfficiency(250)        // buff from 130
     GTMaterials.Osmiridium.getProperty(PropertyKey.ROTOR).setPower(180)             // buff from 130
-    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR).setPower(200)               // buff from 160
+    GTMaterials.Naquadah.getProperty(PropertyKey.ROTOR).setPower(300)               // buff from 160
     GTMaterials.RhodiumPlatedPalladium.getProperty(PropertyKey.ROTOR).setEfficiency(220)    // buff from 155
-    GTMaterials.HSSG.getProperty(PropertyKey.ROTOR).setPower(170)                   // nerf from 205
-    GTMaterials.HSSS.getProperty(PropertyKey.ROTOR).setPower(180)                   // nerf from 250
-    GTMaterials.HSSE.getProperty(PropertyKey.ROTOR).setPower(190)                   // nerf from 280
-    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR).setPower(240)          // buff from 190
-    GTMaterials.TungstenSteel.getProperty(PropertyKey.ROTOR).setPower(180)          // buff from 160
+    GTMaterials.NaquadahAlloy.getProperty(PropertyKey.ROTOR).setPower(320)          // buff from 190
+    GTMaterials.TungstenSteel.getProperty(PropertyKey.ROTOR).setPower(200)          // buff from 160
+    GTMaterials.Osmium.getProperty(PropertyKey.ROTOR).setPower(180)                 // buff from 160
 
     // New turbine rotors from existing GT Materials
-    let DarmstadtiumTurbineProperty = new $RotorProperty(270, 150, 7.0, 10240)
+    let DarmstadtiumTurbineProperty = new $RotorProperty(300, 200, 7.0, 10240)
     GTMaterials.Darmstadtium.setProperty(PropertyKey.ROTOR, DarmstadtiumTurbineProperty)
 
     let CrystalMatrixTurbineProperty = new $RotorProperty(220, 270, 6.0, 10240)


### PR DESCRIPTION
Turbine Rotor rebalance to go with the removal of the durability mechanic.

This time, I used an Excel spreadsheet to visualize how different rotors' stats compared against one another.
<img width="3432" height="1581" alt="Picture1" src="https://github.com/user-attachments/assets/15ea2140-db4b-4827-8d75-7f1c0c342072" />

This PR also removes and hides a collection of rotors that are rarely or never used using a technique new to this repository: EMI offers a way to hide itemstacks using a resourcepack. This technique is necessary since all turbine rotors are the same item but with different NBT.

There's no way to make the Activated Netherite turbine rotor have the enchantment glint other Activated Netherite items have unfortunately. LMK if that's an issue and I can remove the new rotor from the PR.