### PR TITLE
Remove the part about bleeding edge builds in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -71,7 +71,6 @@ By default, Monifactory only supports the mods included with it, and has *option
 **Q. How do I download Monifactory?**
 
 Stable releases of Monifactory can be downloaded from CurseForge using any launcher of your choice (PrismLauncher, CurseForge, etc.)
-Bleeding edge builds can be found [here](https://github.com/Omicron-Industries/Monifactory/releases).
 
 **Q. How do I play Hard Mode/Expert Mode?**
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -71,6 +71,7 @@ By default, Monifactory only supports the mods included with it, and has *option
 **Q. How do I download Monifactory?**
 
 Stable releases of Monifactory can be downloaded from CurseForge using any launcher of your choice (PrismLauncher, CurseForge, etc.)
+We will occasionally release Bleeding Edge builds during the development of larger updates. Since the goal of those builds is to gather direct feedback on WIP features, they will exclusively be available in our [Discord server](https://discord.gg/4jch9Rs2Cq), usually attached to a dev blog entry in the #moni-meowdays channel. 
 
 **Q. How do I play Hard Mode/Expert Mode?**
 


### PR DESCRIPTION
I guess you planned to have bleeding edge builds on the Github Releases page at some point, but only the stable releases (the same as in Curseforge) are there.