### PR TITLE
Add lag mitigation for Snad farms in and around lazy loaded chunks

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/sugarcane.js
+++ b/kubejs/server_scripts/fixes_tweaks/sugarcane.js
@@ -1,0 +1,60 @@
+/**
+ * Under Minecraft's chunk loading system,
+ * chunks at ticket level 32 are called "Block Ticking" or "Lazy Loaded".
+ * Item entities spawned in these chunks never tick:
+ * no gravity, no merge, no despawn, no collection.
+ * They pile up until a player arrives and the server
+ * tries to tick all of them at once.
+ * This code prevents item entites under these conditions
+ * from spawning upon an attempt being made to spawn one.
+ *
+ * No attempts are made to delete items that spawn in an entity ticking chunk,
+ * but later get moved to a lazy-loaded chunk because:
+ * 1. They will have already been collected into stacks
+ * 2. By virtue of their having already been in a entity ticking chunk,
+ *  it shows that the server can handle as many items as there were.
+ * 3. No additional items can build up in this lazy-loaded area
+ *  without triggering the event handler below.
+ *
+ * Written with Claude Code, shared by Mavalle, modified by Xefyr
+ */
+
+// Item entities that can be farmed with Snad, having the highest risk of causing this issue
+const WATCH = [
+    "minecraft:sugar_cane",
+    "minecraft:cactus",
+    "minecraft:bamboo",
+    "minecraft:kelp",
+]
+
+const seen = {}
+
+EntityEvents.spawned(event => {
+    // Only affect items
+    const e = event.entity
+    if (e.type !== "minecraft:item") return
+
+    // Only affect entities on the watchlist
+    const id = e.item.id
+    if (WATCH.indexOf(id) === -1) return
+
+    // Filter out ticking entities (these will collect and despawn eventually)
+    const pos = e.blockPosition()
+    if (e.level.isPositionEntityTicking(pos)) return
+
+    // Right-shift operator truncates floats to integers in Javascript
+    const key = (pos.x >> 4) + "," + (pos.z >> 4)
+
+    // Log a warning to the console when a lazy-loaded item entity matching the watchlist is deleted from a new chunk
+    if (!seen[key]) {
+        seen[key] = true
+        console.warn(
+            "[LazyItems] Item " + id + " spawned in lazy-loaded chunk and was deleted for lag mitigation. " +
+            "Coordinates x=" + pos.x + ", y=" + pos.y + ", z=" + pos.z + ". " +
+            "Further items of this type spawned in this 'lazy loaded' chunk will be deleted as well. " +
+            "If you have a Snad farm there, consider force-loading the chunk and adjacent chunks."
+        )
+    }
+
+    event.cancel()
+})


### PR DESCRIPTION
When a Snad farm improperly chunkloaded, it can cause a buildup of item entities in block-ticking (a.k.a. "lazy loaded") chunks. Because these sorts of chunks don't tick items, the normal lag mitigation approaches MC has for item entities don't trigger. (Collection of entities into stacks and despawning after 5 mins)
This script was created to prevent item entities that are the product of Snad farms from spawning in these block-ticking chunks to prevent the issue.

This PR was AI-assisted, shared by Mavalle in the #moni-dev discord channel and reviewed/modified by yours truly.