### PR TITLE
Make XP requirements for Sculk Vat more forgiving and consume less XP

### DIFF
--- a/kubejs/server_scripts/gregtech/sculk_vat.js
+++ b/kubejs/server_scripts/gregtech/sculk_vat.js
@@ -84,7 +84,7 @@ ServerEvents.recipes(event => {
         .notConsumable("minecraft:sculk_catalyst")
         .itemInputs("1x minecraft:stone")
         .outputFluids("gtceu:sculk 288")
-        .xpRange(56000, 88000)
+        .xpRange(12000, 56000)
         .duration(20 * 3)
         .EUt(GTValues.VA[GTValues.HV])
 
@@ -92,7 +92,7 @@ ServerEvents.recipes(event => {
         .itemInputs("2x kubejs:petri_dish_sculk", "kubejs:hadal_shard")
         .inputFluids("gtceu:mutagen 250", "gtceu:glycerol 1250", "gtceu:isoprene 750")
         .outputFluids("gtceu:hadal_sculk 2000")
-        .xpRange(100000, 120000)
+        .xpRange(96000, 120000)
         .duration(100)
         .EUt(GTValues.VA[GTValues.IV])
 

--- a/kubejs/server_scripts/processing_lines/sculk_bioalloy.js
+++ b/kubejs/server_scripts/processing_lines/sculk_bioalloy.js
@@ -57,7 +57,7 @@ ServerEvents.recipes(event => {
         .itemInputs("kubejs:amalgamated_sculk")
         .inputFluids("gtceu:bioalloy_base 1008")
         .outputFluids("monilabs:sculk_bioalloy 1440")
-        .xpRange(116000, 124000)
+        .xpRange(64000, 80000)
         .duration(60)
         .EUt(GTValues.VA[GTValues.ZPM])
 })


### PR DESCRIPTION
I've gotten the impression recently that the XP side of the Sculk Vat is mainly annoying to deal with, hopefully this makes that aspect less annoying.
The biggest change is to regular Sculk, where the XP consumption is drastically reduced since Sculk should be pretty cheap, especially from the Sculk Vat.