### PR TITLE
move Ender Spores to all modes

### DIFF
--- a/kubejs/startup_scripts/registry/item_registry.js
+++ b/kubejs/startup_scripts/registry/item_registry.js
@@ -465,10 +465,8 @@ StartupEvents.registry("item", event => {
         .texture("kubejs:item/mod/thermal/clathrate/resonant_clathrate")
 
     // Ender Spore
-    if (!doHNN) {
-        event.create("ender_spore")
-            .texture("kubejs:item/ender_spore")
-    }
+    event.create("ender_spore")
+        .texture("kubejs:item/ender_spore")
 
     // Thermal Custom Augments Classes
     const $AugmentItem = Java.loadClass("cofh.thermal.lib.common.item.AugmentItem");


### PR DESCRIPTION
ender spore recipes in `greenhouse.js` were for all modes so nm had kjs errors
assumed that intended behavior was for spores to be for all modes instead of only hm/em