### PR TITLE
correct quests for expert completion

### DIFF
--- a/config/ftbquests/quests/chapters/groundwork.snbt
+++ b/config/ftbquests/quests/chapters/groundwork.snbt
@@ -1996,6 +1996,7 @@
 			disable_toast: true
 			hide_until_deps_visible: true
 			id: "0C10EC03A01E7334"
+			optional: true
 			shape: "hexagon"
 			tasks: [{
 				id: "5326C255DC39819A"

--- a/config/ftbquests/quests/chapters/simulating_resources.snbt
+++ b/config/ftbquests/quests/chapters/simulating_resources.snbt
@@ -541,6 +541,7 @@
 			]
 			hide_until_deps_visible: true
 			id: "715BC5C7DAC53B7B"
+			optional: true
 			rewards: [{
 				id: "518DD0C9237B4DBC"
 				item: "kubejs:moni_quarter"

--- a/config/ftbquests/quests/chapters/some_assembly_required.snbt
+++ b/config/ftbquests/quests/chapters/some_assembly_required.snbt
@@ -1315,6 +1315,7 @@
 			hide_dependency_lines: true
 			hide_until_deps_visible: true
 			id: "069D243B809E0D5D"
+			optional: true
 			rewards: [{
 				id: "05346384A9F2EAF1"
 				item: "kubejs:moni_quarter"
@@ -1439,6 +1440,7 @@
 			hide_dependency_lines: true
 			hide_until_deps_visible: true
 			id: "10E63A0428E6BA25"
+			optional: true
 			size: 2.0d
 			subtitle: "{moni.quest.069D243B809E0D5D.subtitle}"
 			tasks: [{

--- a/config/ftbquests/quests/chapters/the_factory.snbt
+++ b/config/ftbquests/quests/chapters/the_factory.snbt
@@ -2053,6 +2053,7 @@
 			]
 			hide_until_deps_visible: true
 			id: "4F239316765C7CA1"
+			optional: true
 			rewards: [{
 				id: "189732EC89DA656B"
 				item: "kubejs:moni_nickel"


### PR DESCRIPTION
- Resonant Clathrate is impossible in Hard and Expert because it requires the `doHNN` stage
- Simulating Mobs is impossible for the same reason
- Wireless Active Transformer is impossible in Normal because it requires `doQuantumCoolant`
- PTERB is impossible in Hard and Expert because it requires the mutually exclusive `dontQuantumCoolant`
- Item Cards is impossible in Expert because it requires `doLaserIO`, which is disabled

These are the changes we needed to make to complete all quests in Moni :).