### PR TITLE
Use Iridium for MEGA Fluid Cell Housing

### DIFF
--- a/kubejs/server_scripts/mods/AE2.js
+++ b/kubejs/server_scripts/mods/AE2.js
@@ -758,7 +758,7 @@ ServerEvents.recipes(event => {
         "ABA"
     ], {
         A: "gtceu:fine_lumium_wire",
-        B: "monilabs:crystal_matrix_plate"
+        B: "gtceu:iridium_plate"
     }).id("kubejs:mega/fluid_cell_housing")
 
     event.remove({ id: "megacells:network/cell_dock" })


### PR DESCRIPTION
As requested in #monifactory and/or #moni-dev.

Directed to `main` instead of `0.14-dev` because this is a minor balance PR, and not necessary for nor dependent on any 0.14-related content.