### PR TITLE
Remove Iridium from High Power Casing recipe

### DIFF
--- a/kubejs/server_scripts/fixes_tweaks/active_transformer.js
+++ b/kubejs/server_scripts/fixes_tweaks/active_transformer.js
@@ -8,9 +8,8 @@ ServerEvents.recipes(event => {
             "#forge:frames/stainless_steel",
             "6x #forge:plates/platinum",
             "#gtceu:circuits/hv",
-            "8x #forge:fine_wires/iridium",
             "8x #forge:fine_wires/neptunium_palladium_aluminium",
-            "2x gtceu:osmium_single_wire",
+            "4x gtceu:osmium_single_wire",
         )
         .itemOutputs("2x gtceu:high_power_casing")
         .duration(100).EUt(GTValues.VA[GTValues.EV])


### PR DESCRIPTION
Iridium is used more frequently relative to Osmium than the platline can supply it. This results in a surplus of Osmium or deficit of Iridium. To correct the imbalance, this PR removes Iridium from the High Power Casing recipe.

I suggest this gets merged at the same time as #2736 or earlier.

Directed to `main` instead of `0.14-dev` because this is a minor balance PR, and not necessary for nor dependent on any 0.14-related content.