### PR TITLE
Fix #2733: require MV+ Atomic Reconstructor for quest

### DIFF
--- a/config/ftbquests/quests/chapters/groundwork.snbt
+++ b/config/ftbquests/quests/chapters/groundwork.snbt
@@ -512,10 +512,6 @@
 						items: [
 							{
 								Count: 1b
-								id: "gtceu:lv_atomic_reconstructor"
-							}
-							{
-								Count: 1b
 								id: "gtceu:mv_atomic_reconstructor"
 							}
 							{


### PR DESCRIPTION
Removes the LV Atomic Reconstructor option from the quest's item filter. Since a Palis Block is required for the next quest, for the Enchanter, and that is an MV only recipe, it doesn't make sense to allow an LV Atomic Reconstructor in the OR filter.

Closes #2733 