### PR TITLE
Fix #2701: pack mode switcher fails on paths with spaces

### DIFF
--- a/pack-mode-switcher.bat
+++ b/pack-mode-switcher.bat
@@ -35,8 +35,8 @@ if not defined MODE (
     color 9
 
     set CURRENT_MODE="normal"
-    if exist %modeFile% (
-        set /p CURRENT_MODE=<%modeFile%
+    if exist "%modeFile%" (
+        set /p CURRENT_MODE=<"%modeFile%"
     )
     if "%SILENT%"=="false" (
         echo Monifactory ^| Pack Mode Switcher
@@ -68,24 +68,24 @@ exit /b 1
 
 :copyNormal
 robocopy "%normalCfgPath%" "%targetPath%" *.* /e /nfl /ndl >nul
-echo normal > %modeFile%
+echo normal > "%modeFile%"
 goto success
 
 :copyHard
 robocopy "%hardCfgPath%" "%targetPath%" *.* /e /nfl /ndl >nul
-echo hard > %modeFile%
+echo hard > "%modeFile%"
 goto success
 
 :copyExpert
 robocopy "%hardCfgPath%" "%targetPath%" *.* /e /nfl /ndl >nul
 robocopy "%expertCfgPath%" "%targetPath%" *.* /e /nfl /ndl >nul
-echo expert > %modeFile%
+echo expert > "%modeFile%"
 goto success
 
 
 :success
 if "%SILENT%"=="false" (
-    set /p NEWMODE=<%modeFile%
+    set /p NEWMODE=<"%modeFile%"
     echo Successfully switched pack mode to !NEWMODE!
 )
 exit /b 0


### PR DESCRIPTION
Several uses of %modeFile% in pack-mode-switcher.bat were unquoted, so cmd.exe splits on spaces in the instance path — matching how %normalCfgPath%, %targetPath%, etc. are already quoted elsewhere in the same file. I dont have a Windows environment on hand so I wasn't able to test it in practice, but it should work. If requested I can test it properly soon.

Closes #2701