### PR TITLE
Fix spelling in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ KubeJS offers a feature to automatically load resource packs & datapacks put int
 4. Do not leave any unused files or assets in these folders! One example is how there used to be an entire suite of Draconic Evolution-themed casings before the theming was switched to the Deep Dark instead. Those unused assets were left in the folder for _months_ after the switch. Debug assets such as those in `kubejs\assets\kubejs\textures\block\debug` are exempt.
 
 ## Optional Compats ##
-Optional Compatiblities for mods should be balanced so that they fit naturally in the modpack's progression without overshadowing existing options. For example, an optional compatability should not have wireless be unlocked before it's possible in the base modpack. Optional Compatibilies serve to extend and add additional options, not replace.
+Optional Compatibilities for mods should be balanced so that they fit naturally in the modpack's progression without overshadowing existing options. For example, an optional compatibility should not have wireless be unlocked before it's possible in the base modpack. Optional Compatibilities serve to extend and add additional options, not replace.
 
 ## Updating Mods ##
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you want to switch the pack mode on a dedicated server, follow these instruct
       java -jar ${Server Root}\mods\monilabs-*.jar ${N/H/E}
       ```
     - You'll need to replace ${Server Root} with the path of your server, E.G ``C:\MonilabsServer`` or ``/var/opt/moniserver/``.
-    Keep in mind these are most likely **not** be the path of your Monifactory server, open your perfered shell/command interface, for Windows run ``cd`` without any parameters, for Mac/Linux/FreeBSD, run ``pwd``.
+    Keep in mind these are most likely **not** be the path of your Monifactory server, open your preferred shell/command interface, for Windows run ``cd`` without any parameters, for Mac/Linux/FreeBSD, run ``pwd``.
     - ${N/H/E} is the mode of Moni you want to switch to, N is for Normal Mode, H is for Hard Mode, and E is for Expert Mode
     - Typing in nothing will prompt you to change your pack mode
 
@@ -108,7 +108,7 @@ To spice up your Monifactory experience, you can add any of the following mods t
 6. ``unzip server.zip``
 7. If you have already or will install ProjectRed Illumination as an optional dependency for clients, you must remember to manually copy the mod ``ProjectRed-VERSION-illumination.jar`` from your client mods folder to the server mods folder to avoid crashes. Note: GTMolDraw is purely client side and thus does not need to be copied as well.
 8. On Monifactory versions 0.12.X and older, move the contents of the overrides folder (from server.zip) into the server directory, this can be done with the command ``mv overrides/* .``
-9. Use ``./run.sh`` to generate the eula.txt, then again after you accepted run it again to start the server. Modifying the server.properties file to change the port may be neccesary.
+9. Use ``./run.sh`` to generate the eula.txt, then again after you accepted run it again to start the server. Modifying the server.properties file to change the port may be necessary.
 10. To upgrade an existing Monifactory server, see [FAQ.md](FAQ.md).
 
 ## Contributing


### PR DESCRIPTION
Fixes spelling in the README and contributing guide.

**README.md**
- "open your perfered shell/command interface" -> "preferred"
- "change the port may be neccesary" -> "necessary"

**CONTRIBUTING.md** (all in the optional-compatibility paragraph)
- "Optional Compatiblities" -> "Compatibilities"
- "an optional compatability" -> "compatibility"
- "Optional Compatibilies serve" -> "Compatibilities"

Documentation only. I left the mod config files under `config/` alone, since those are
generated by the mods themselves and would be overwritten anyway.
