### PR TITLE
Updated PhCC to 0.14.0 and reuploaded the config.

### DIFF
--- a/config/phoenix_chromatic_codes.yaml
+++ b/config/phoenix_chromatic_codes.yaml
@@ -1,0 +1,67 @@
+colors:
+  # Whether named bracket codes are case-sensitive.
+  # true  -> &[Phoenix] and &[phoenix] are two completely different codes.
+  # false -> &[Phoenix] and &[phoenix] both resolve to whichever was registered first (lowercased).
+  # Requires a game restart to take effect.
+  # Default: true
+  namedCodesCaseSensitive: true
+
+  # Add custom single-character color codes here.
+  # Format: 'char:hex' (e.g., 'z:BF00FF')
+  # Do NOT use vanilla codes (0-9, a-f, k-o, r) as keys — see comment above.
+  customColors:
+    - z:BF00FF
+    - t:00FF80
+    - s:0B585C
+
+  # Add custom single-character gradient/effect codes here.
+  # Format: 'char:colorSpeed:moveSpeed:movementId:hex1,hex2...'
+  # Example: 'w:1.0:0.5:wave:rainbow'
+  # Movement IDs: wave, shake, pulse, static_rainbow, glitch, discord, breath, stretch, none
+  # Discord is the effect you see on servers with boosts, that smooth gradient. This one needs exactly two hex codes to work properly.
+  # Do NOT use vanilla codes (0-9, a-f, k-o, r) as keys — see comment above.
+  customGradients:
+    - w:1.0:1.0:wave:rainbow
+    - p:1.0:2.0:pulse:FF0000,990000
+    - *:1.5:0.0:static_rainbow:rainbow
+    - g:1.0:3.0:glitch:00FF00,005500
+    - y:2.5:0.0:none:FF0000,FFFF00,00FF00
+    - ^:1.0:0.0:discord:FC8EAC,8F00FF
+    - #:0.0:2.0:breath:FF00FF
+    - %:0.0:2.0:stretch:FF00FF
+
+  # Named color codes using bracket syntax: '[name]:hex'
+  # Use as &[name] or §[name] in text.
+  # Example: '[phoenix]:BF00FF'  ->  use as &[phoenix] in chat
+  # Named codes are completely separate from single-char codes — no overlap ever.
+  namedColors:
+    - [phoenix]:BF00FF
+
+  # Named gradient/effect codes using bracket syntax.
+  # Format: '[name]:colorSpeed:moveSpeed:movementId:hex1,hex2...'
+  # Use as &[name] or §[name] in text.
+  # Movement IDs: wave, shake, pulse, static_rainbow, glitch, discord, breath, stretch, none
+  # Example: '[rainbow]:1.0:1.0:wave:rainbow'  ->  use as &[rainbow] in chat
+  # Named codes are completely separate from single-char codes — no overlap ever.
+  namedGradients:
+    - [rainbow]:1.0:1.0:wave:rainbow
+    - [matrix]:1.0:3.0:glitch:00FF00,005500
+    - [big]:0.0:1.5:size:FFFFFF
+    - [huge]:0.0:2.5:size:FFFFFF
+    - [frozen]:0.0:0.0:none:FF00FF,00FFFF
+    - [glossy]:0.0:0.0:mirror:FF0000,00FF00,0000FF
+    - [sunset]:0.0:0.0:vertical:FFaa00,FF00aa
+    - [spaced]:0.0:4.0:spacing:FFFFFF
+    - [speed]:0.0:0.45:slant:FFFFFF
+    - [neon_ocean]:1.2:1.0:rainbow_wave:rainbow
+    - [cyber]:1.0:1.0:chroma:FF0055,00FFFF
+    - [uphill]:0.0:0.2:shear:FFFFFF
+    - [rgb_ticker]:1.5:0.0:chroma_wave:rainbow
+    - [jelly]:0.0:1.2:wobble:00FFaa
+    - [elastic]:0.0:1.0:compress:FFFFFF
+    - [ghost]:0.0:0.0:fade:FFFFFF
+    - [3d_block]:0.0:5.0:3d:FFCC00,443300
+    - [digital]:1.5:0.0:matrix_rain:00FF00
+    - [flip]:0.0:1.5:3d_spin:FFFFFF
+    - [plasma]:1.5:0.0:liquid_plasma:FFFFFF
+

--- a/manifest.json
+++ b/manifest.json
@@ -46,7 +46,7 @@
       "required": true
     },
     {
-      "fileID": 7985373,
+      "fileID": 8286152,
       "projectID": 1483210,
       "required": true
     },


### PR DESCRIPTION
Somewhere in dev the config file for phcc was lost leading to an issue with the prismatic crucible crashing due to the teal code not existing and the sculk vat got the shake code instead of it's color. 

I also updated phcc because of an ftbquests newline issue and an issue with kjs overridden lang using base mc color codes. 

I tested this in pack checking out the prismaC, sculk vat, and the chroma hatches.

I need to uhh, rewrite the phcc config at some point.