### PR TITLE
Change the Pipez wrench recipe to be gated earlier

### DIFF
--- a/kubejs/server_scripts/mods/pipez.js
+++ b/kubejs/server_scripts/mods/pipez.js
@@ -135,7 +135,7 @@ ServerEvents.recipes(event => {
         "N  "
     ], {
         P: "#forge:ingots/iron",
-        R: "redstone_arsenal:obsidian_rod",
+        R: "#forge:rods/long/lead",
         N: "#forge:nuggets/iron"
     }).id("pipez:wrench")
 


### PR DESCRIPTION
The Wrench from Pipez is a necessary part of configuring the titular pipes from the mod. However, it was gated behind Blaze Powder and Obsidian, which are gated behind either the Nether, HV, or Elemental Reduction Fluid. This is unacceptable for a key part of a mod that's meant to be useful for _earlygame_ logistics, so this PR gates the tool much earlier, behind Lead instead.