### PR TITLE
Add Natural Gas to void dimension

### DIFF
--- a/kubejs/server_scripts/worldgen/fluidVeins.js
+++ b/kubejs/server_scripts/worldgen/fluidVeins.js
@@ -10,11 +10,11 @@ const infernalVenusBarrensResourceKey = ResourceKey.create(Registries.BIOME, "ad
 
 GTCEuServerEvents.fluidVeins(event => {
 
-    // Void dim oil
+    // Void dim oil and natural gas
     event.add("kubejs:void/raw_oil", vein => {
         vein.dimensions("javd:void")
         vein.fluid(() => Fluid.of("gtceu:oil_medium").fluid)
-        vein.weight(100)
+        vein.weight(40)
         vein.minimumYield(200)
         vein.maximumYield(250)
         vein.depletionAmount(1)
@@ -31,6 +31,17 @@ GTCEuServerEvents.fluidVeins(event => {
         vein.depletionAmount(1)
         vein.depletionChance(50)
         vein.depletedYield(20)
+    })
+
+    event.add("kubejs:void/natural_gas", vein => {
+        vein.dimensions("javd:void")
+        vein.fluid(() => Fluid.of("gtceu:natural_gas").fluid)
+        vein.weight(25)
+        vein.minimumYield(75)
+        vein.maximumYield(125)
+        vein.depletionAmount(1)
+        vein.depletionChance(50)
+        vein.depletedYield(15)
     })
 
 


### PR DESCRIPTION
Title. Also reduces the frequency of Raw Oil.

This is another power generation balance change: The ease of access to Raw Oil in the void dimension is one of the many factors that led to Naphtha's dominance: the convenience of sourcing your fuel from a raw material found (nearly) anywhere in the same dimension you build your base in.

Reducing Raw Oil's frequency and adding Natural Gas reduces the impact of that effect for Naphtha, and makes LPG (and with it, gas turbines) more attractive as an option for power generation.