### PR TITLE
Fix Supercritical Core's Null output

### DIFF
--- a/kubejs/server_scripts/gregtech/Prismatic_Crucible.js
+++ b/kubejs/server_scripts/gregtech/Prismatic_Crucible.js
@@ -239,7 +239,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.gtceu.chromatic_transcendence("prismatic_core_supercritical_void")
         .itemInputs("kubejs:supercritical_prismatic_core")
-        .outputFluids("gtceu:meta_null 4480")
+        .outputFluids("gtceu:meta_null 6720")
         .inputColor(PrismaticColor.ANY)
         .outputStatesRelative(0)
         .duration(20)


### PR DESCRIPTION
Xef, you forgor 💀
Supercritical Null's recipe is in a different place, so it was missed during #2489.
It was supposed to give 6720L Null (5568 for Indigo Cores, plus the 1152 Trans Matrix used in the Pink step), but gave 4480L instead.
kekw.