### PR TITLE
Add Gasses to the fuels that can blast Cryolobus

### DIFF
--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -118,6 +118,7 @@ ServerEvents.recipes(event => {
         [400, 1600, "gtceu:gasoline"],
         [250, 1200, "gtceu:high_octane_gasoline"],
         [150, 900, "gtceu:jean_gasoline"],
+        [500, 2000, "gtceu:nitrobenzene"],
         [250, 1600, "gtceu:wither_gas"]
     ]
 

--- a/kubejs/server_scripts/random_recipes.js
+++ b/kubejs/server_scripts/random_recipes.js
@@ -117,7 +117,8 @@ ServerEvents.recipes(event => {
         [500, 1600, "gtceu:cetane_boosted_diesel"],
         [400, 1600, "gtceu:gasoline"],
         [250, 1200, "gtceu:high_octane_gasoline"],
-        [150, 900, "gtceu:jean_gasoline"]
+        [150, 900, "gtceu:jean_gasoline"],
+        [250, 1600, "gtceu:wither_gas"]
     ]
 
     for (const [mB, duration, id] of cryolobusFuels) {


### PR DESCRIPTION
To reduce the necessity for production of and reliance upon combustion fuels, I suggest that Wither Gas and Nitrobenzene be added to the list of fuels that can be used to blast Cryolobus.